### PR TITLE
Manage permissions on jetty-realm.properties

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,10 @@ class pe_activemq_jolokia {
     file {'/etc/puppetlabs/activemq/jetty.xml':
       source => 'puppet:///modules/pe_activemq_jolokia/jetty.xml',
     }
+
+    file {'/etc/puppetlabs/activemq/jetty-realm.properties':
+      mode => '0600',
+    }
   } else {
     File <| title == '/etc/puppetlabs/activemq/jetty.xml' |> {
       source => 'puppet:///modules/pe_activemq_jolokia/jetty.xml',


### PR DESCRIPTION
This patch manages the permissions on jetty-realm.properties when the
PE version is less than 2016.5.0 as the installer can produce a file
that is unreadable by the `pe-activemq` user. 2016.5 and later manage
these permissions via the puppet_enterprise module.