### PR TITLE
Require pe-activemq package before managing files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,11 +9,12 @@ class pe_activemq_jolokia {
 
   # Set up the additional configuration files Jolokia needs
   File {
-    ensure => file,
-    owner  => 'pe-activemq',
-    group  => 'pe-activemq',
-    mode   => '0600',
-    notify => Service['pe-activemq'],
+    ensure  => file,
+    owner   => 'pe-activemq',
+    group   => 'pe-activemq',
+    mode    => '0600',
+    require => Package['pe-activemq'],
+    notify  => Service['pe-activemq'],
   }
 
   # Use an updated jetty.xml source that enables Jolokia


### PR DESCRIPTION
This patch adds a `require => Pacakge['pe-activemq']` to the files managed
by the pe_activemq_jolokia class. This ensures that directories created by the
package will be present when a new hub or spoke is built out.